### PR TITLE
Use path.sep instead of "/" to allow hosting cross-platform

### DIFF
--- a/src/server/v1/modules/ModService.ts
+++ b/src/server/v1/modules/ModService.ts
@@ -132,9 +132,9 @@ export default class ModService {
                 try {
                     await new Promise((res, rej) => {
                         const mkdir = (dirPath: string, root = "") => {
-                            const dirs = dirPath.split("/");
+                            const dirs = dirPath.split(path.sep);
                             const dir = dirs.shift();
-                            root = (root || "") + dir + "/";
+                            root = (root || "") + dir + path.sep;
 
                             try {
                                 fs.mkdirSync(root);
@@ -144,7 +144,7 @@ export default class ModService {
                                 }
                             }
 
-                            return !dirs.length || mkdir(dirs.join("/"), root);
+                            return !dirs.length || mkdir(dirs.join(path.sep), root);
                         };
                         mkdir(fullPath);
                         fs.writeFile(fullFile, file.buffer, { flag: "w" }, () => {


### PR DESCRIPTION
Just a simple change to use path.sep instead of "/" when creating directories; Using "/" caused the directories to not be able to be created properly on a windows host.

Note: It doesn't have to be changed in line 128 as path.join is used afterwards, which seems to be changing/sanitizing it properly, as intended.