### PR TITLE
Allow users to edit their own mods

### DIFF
--- a/src/client/app/views/mod/Mod.tsx
+++ b/src/client/app/views/mod/Mod.tsx
@@ -55,6 +55,7 @@ export default class Mod extends Component<{ mod: IMod; user: any | null; refres
                             onChange={e => {
                                 if (e.target.value) { this.update({ name: e.target.value }); }
                             }}
+                            disabled={!this.props.user.admin}
                         />
                     </InputGroup>
                     <InputGroup>
@@ -65,6 +66,7 @@ export default class Mod extends Component<{ mod: IMod; user: any | null; refres
                             onChange={e => {
                                 if (e.target.value) { this.update({ version: e.target.value }); }
                             }}
+                            disabled={!this.props.user.admin}
                         />
                     </InputGroup>
                     {this.props.user && this.props.user.admin && (
@@ -134,7 +136,7 @@ export default class Mod extends Component<{ mod: IMod; user: any | null; refres
         return (
             <div className="mod__wrapper">
                 <div className="mod">
-                    {mod.status !== "declined" && this.props.user && (this.props.user.admin || this.props.user._id === this.props.mod.authorId) && (
+                    {mod.status !== "declined" && this.props.user && (this.props.user.admin || (this.props.user._id === this.props.mod.authorId && mod.status !== "approved")) && (
                         <span className="edit" onClick={() => this.setState({ editing: !this.state.editing })}>
                             <i className="fa fa-edit" />
                         </span>

--- a/src/server/v1/modules/ModService.ts
+++ b/src/server/v1/modules/ModService.ts
@@ -90,63 +90,77 @@ export default class ModService {
         return mods.map(mod => mod as IDbMod);
     }
 
-    public async update(mod: IDbMod, isInsert = false) {
-        if (!mod._id) {
+    public async update(changes: IDbMod, isInsert = false) {
+        if (!changes._id) {
             throw new ParameterError("mod._id");
         }
-        const existing = await this.dao.get(toId(mod._id));
-        if (!this.ctx.user || (!this.ctx.user.admin && toId(mod.authorId).toHexString() !== toId(this.ctx.user._id).toHexString())) {
+        const existing = await this.dao.get(toId(changes._id));
+        if (!this.ctx.user || (!this.ctx.user.admin && toId(existing.authorId).toHexString() !== toId(this.ctx.user._id).toHexString())) {
             throw new ServerError("mod.no_permissions");
         }
 
-        const updateMod: Partial<IDbMod> = {};
-        const authenticationProps = ["status", "required"];
-        for (const prop in mod) {
-            if (prop in mod) {
-                if (prop in authenticationProps && !(this.ctx.user && this.ctx.user.admin)) {
-                    throw new ParameterError(`mod.auth_required.${prop}`);
+        if (!isInsert) {
+            if (!this.ctx.user.admin && existing.status === "approved") {
+                throw new ParameterError("mod.auth_required_post_approval");
+            }
+            const baseEditProps = new Set(["description", "link", "dependencies"]);
+            const modEditProps = new Set(["name", "version", "status", "required", "category"]);
+            for (const prop of Object.keys(changes)) {
+                const val = changes[prop];
+                if (typeof val !== "string" && typeof val !== "boolean" && !(val instanceof String) && !(val instanceof Boolean)) {
+                    // Might be an attempt at MongoDB injection
+                    throw new ParameterError("mod.illegal_value_type");
                 }
-                updateMod[prop] = mod[prop];
+                if (baseEditProps.has(prop)) {
+                    // If they can edit anything, they can edit this
+                } else if (modEditProps.has(prop)) {
+                    if (!this.ctx.user.admin) {
+                        throw new ParameterError(`mod.auth_required.${prop}`);
+                    }
+                } else if (prop !== "_id") {
+                    // "_id" will get deleted in a bit anyway
+                    throw new ParameterError("mod.illegal_property");
+                }
             }
         }
-        if (Object.keys(updateMod).length === 0) {
+        if (Object.keys(changes).length === 0) {
             return new ParameterError(`mod.no_properties_updated`);
         }
-        updateMod["updatedDate"] = new Date();
-        if (updateMod.dependencies && typeof updateMod.dependencies === "string") {
-            updateMod.dependencies = (await this.dao.getDependencies(updateMod.dependencies)).map(item => toId(item._id));
+        changes["updatedDate"] = new Date();
+        if (changes.dependencies && typeof changes.dependencies === "string") {
+            changes.dependencies = (await this.dao.getDependencies(changes.dependencies)).map(item => toId(item._id));
         }
-        if (updateMod.status && updateMod.status === "approved") {
+        if (changes.status && changes.status === "approved") {
             const older = await this.dao.getOldVersions(existing);
             await this.dao.updateMatch({ _id: { $in: older.map(i => toId(i._id)) } }, { status: "inactive" });
         }
-        if (updateMod["_id"]) {
-            delete updateMod["_id"];
+        if (changes["_id"]) {
+            delete changes["_id"];
         }
         new AuditLogService(this.ctx).create(
             this.ctx.user,
             "UPDATE",
             "MOD",
             {
-                ...Object.keys(updateMod)
+                ...Object.keys(changes)
                     .map(k => ({ [k]: existing[k] }))
                     .reduce((acc, cur, i) => ({ ...acc, ...cur }), {})
             },
-            updateMod
+            changes
         );
-        if (Object.keys(updateMod).indexOf("status") !== -1 && !isInsert) {
-            const newStatus = updateMod.status;
+        if (Object.keys(changes).indexOf("status") !== -1 && !isInsert) {
+            const newStatus = changes.status;
             new DiscordManager().sendWebhook(`${this.ctx.user.username} ${newStatus} ${existing.name} v${existing.version}`, [], "https://beatmods.com");
             // } else if (!isInsert) {
             //     new DiscordManager().sendWebhook(
             //         `${this.ctx.user.username} updated ${existing.name} v${existing.version}`,
-            //         Object.keys(updateMod)
+            //         Object.keys(changes)
             //             .filter(i => i !== "updatedDate" && i !== "dependencies")
-            //             .map(i => ({ name: i, value: updateMod[i] })) as dynamic[],
+            //             .map(i => ({ name: i, value: changes[i] })) as dynamic[],
             //         "https://beatmods.com"
             //     );
         }
-        return (await this.dao.update(toId(mod._id), updateMod)) as IDbMod;
+        return (await this.dao.update(toId(existing._id), changes)) as IDbMod;
     }
 
     public async create(


### PR DESCRIPTION
It seems like this was intended but didn't work. This allows users to edit their mod's description, more info link, and dependencies pre-approval even if they aren't a admin.

TODO: should users be able to edit declined mods? Inactive mods? What about admins?

This has been tested in a couple different cases, but could probably use another test run.