### PR TITLE
Updated landing page

### DIFF
--- a/src/client/app/views/home/index.tsx
+++ b/src/client/app/views/home/index.tsx
@@ -16,13 +16,10 @@ export default class Home extends Component<{ history: any; user: any | null }> 
                 <span>Mod installers are available:</span>
                 <ul>
                     <li>
-                        <a href="https://github.com/beat-saber-modding-group/BeatSaberModInstaller/releases/latest">Beat Saber Mod Installer</a>
+                        <a href="https://github.com/Assistant/ModAssistant/releases/latest">ModAssistant</a>
                     </li>
                     <li>
                         <a href="https://bsaber.com/beatdrop/">BeatDrop</a>
-                    </li>
-                    <li>
-                        <a href="https://github.com/Assistant/ModAssistant/releases/latest">ModAssistant</a>
                     </li>
                 </ul>
             </Container>


### PR DESCRIPTION
The landing page on BeatMods still lists the now outdated Beat Saber Mod Manager as an available mod installer, which is also listed as the first entry. I assume this is one of the reason why every now and then someone ends up in BSMG #pc-mod-support with this as an issue.

This patch removes the link to Beat Saber Mod Manager and lists ModAssistant as the first entry.

I'm unsure about BeatDrop. I've never used it to install mods, but based on dealing with and lurking in #pc-mod-support, it seems to be a somewhat regular source of problems and everyone gets advised to use ModAssistant instead. So, maybe it shouldn't be listed anymore?

I also ran a quick test in a dev VM for it - seems to work:
![2019-11-12 01_24_40-BeatMods](https://user-images.githubusercontent.com/42559603/68631495-58b05c00-04eb-11ea-831d-5f343db28d09.png)
